### PR TITLE
5871 Fix signing of archive by looking for alternate task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,7 +124,7 @@ subprojects {
     }
 
     signing {
-        required { !version.endsWith("SNAPSHOT") && gradle.taskGraph.hasTask('uploadArchives') }
+        required { !version.endsWith("SNAPSHOT") && (gradle.taskGraph.hasTask('uploadArchives') || gradle.taskGraph.hasTask(':uploadArchives')) }
         sign configurations.archives
     }
 


### PR DESCRIPTION
Simple cleanup of the signing condition, being tolerant of the task being "uploadArchives" or ":uploadArchives".